### PR TITLE
Fix misspelled env var SNAP_DESKTOP_RUNTIME

### DIFF
--- a/snap/local/scripts/private-fontcache
+++ b/snap/local/scripts/private-fontcache
@@ -27,7 +27,7 @@ function make_user_fontconfig {
   echo "  <cachedir prefix=\"xdg\">fontconfig</cachedir>"
   echo "  <cachedir>$SNAP_DATA/fontconfig</cachedir>"
   echo "  <include ignore_missing=\"yes\">/etc/fonts/fonts.conf</include>"
-  if [ ! -z $SNAP_DESTKOP_RUNTIME ]; then
+  if [ ! -z $SNAP_DESKTOP_RUNTIME ]; then
     echo "  <include ignore_missing=\"yes\">${SNAP_DESKTOP_RUNTIME}/etc/fonts/fonts.conf</include>"
   fi
   echo "</fontconfig>"


### PR DESCRIPTION
SNAP_DESTKOP_RUNTIME -> SNAP_DESKTOP_RUNTIME