### PR TITLE
Added homeishome-launch and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Snap Status](https://build.snapcraft.io/badge/ogra1/zoom-snap.svg)](https://build.snapcraft.io/user/ogra1/zoom-snap)
+[![Zoom Client](https://snapcraft.io/zoom-client/badge.svg)](https://snapcraft.io/zoom-client)
 
 # zoom-client snap
 
@@ -27,6 +27,9 @@ To install the snap package, simply use
 ```
 sudo snap install zoom-client
 ```
+### Note:
+On some distributions, please install the snap using `--devmode` (e.g. Pop). 
+
 Details about installing on various distributions that do not come with snapd out of the box can be found at the bottom of https://snapcraft.io/zoom-client
 
 # Building

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,9 @@ architectures:
   - build-on: amd64
     run-on: amd64
 
+assumes:
+  - command-chain
+  
 apps:
   zoom-client:
     command: bin/launcher.sh
@@ -24,6 +27,7 @@ apps:
        - bin/desktop-launch
        - snap/command-chain/alsa-launch
        - bin/private-fontcache
+       - bin/homeishome-launch        
     environment:
       LD_LIBRARY_PATH: $SNAP/zoom/Qt/lib:$SNAP/zoom:$LD_LIBRARY_PATH
       ALWAYS_USE_PULSEAUDIO: 1
@@ -67,6 +71,11 @@ layout:
     symlink: $SNAP_DATA/os-release
 
 parts:
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch   
+
   qt5:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: qt


### PR DESCRIPTION
As the title states, I've added `homeishome-launch` to improve the user experience for saving files, and getting straight to `/home/$USER` instead of the snap's directory.

Added the newer snap badge.

Added verbiage for installing this snap on distros, such as Pop!, using `--devmode`. 

I've successfully built the snap and have it installed on my machine running Pop! right now, and works like a charm. 

I also wanted to thank you for the help you've rendered to me on my own projects and wanted to repay the favor. Consider this small contribution as a start. 