### PR TITLE
Add shared-memory and posix-mq interfaces to fix background blur

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,11 +56,23 @@ plugs:
   browser-sandbox:
     interface: browser-support
     allow-sandbox: true
+  shared-memory:
+    private: true
 
 hooks:
   configure:
     plugs:
       - system-observe
+
+slots:
+  dummymq:
+    interface: posix-mq
+    path: [/zoom,]
+    permissions:
+      - read
+      - write
+      - create
+      - delete
 
 layout:
   /etc/os_release:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -159,6 +159,7 @@ parts:
       - libva-drm2
       - libva-x11-2
       - libvdpau1
+      - libxcb-cursor0
       - libxcb-icccm4
       - libxcb-image0
       - libxcb-keysyms1


### PR DESCRIPTION
Add shared-memory and posix-mq interfaces to fix background blur

As suggested by Peter Bui <pbui@bx612.space>, add a shared-memory plug
to allow the Zoom snap to create the files like

    /dev/shm/aomshm.337bce.0

that it uses internally to communicated with the background blur helper
processes it creates.

Also add a dummy posix-mq slot to allow Zoom to create and manage the
POSIX message queues it uses for communication with the helper process.

This should fully fix issue #128.