### PR TITLE
Wayland hackery

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -12,6 +12,7 @@ if [ ! -n "$DISABLE_WAYLAND" ] && [ -n "$WAYLAND_DISPLAY" ]; then
   export QT_QPA_PLATFORM=wayland
 else
   export QT_QPA_PLATFORM=xcb
+  export XDG_SESSION_TYPE=""
 fi
 
 if echo "$@" | grep -q "\-\-transcoding"; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,6 @@ apps:
     environment:
       LD_LIBRARY_PATH: $SNAP/zoom/Qt/lib:$SNAP/zoom:$SNAP/zoom/cef:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       ALWAYS_USE_PULSEAUDIO: 1
-      XDG_SESSION_TYPE: ""
     desktop: usr/share/applications/Zoom.desktop
     extensions: [ gnome ]
     plugs:


### PR DESCRIPTION
Allow using native wayland when it's available and support disabling wayland with DISPLAY_WAYLAND=1 at runtime.

Note: This is just a draft because zoom is crashing when actually using wayland, when falling back to Xwayland it does work but of course doesn't handle screen sharing for native wayland windows.